### PR TITLE
Search failing with NullPointerException for certain queries

### DIFF
--- a/src/main/java/ulcambridge/foundations/viewer/search/SearchResult.java
+++ b/src/main/java/ulcambridge/foundations/viewer/search/SearchResult.java
@@ -1,5 +1,6 @@
 package ulcambridge.foundations.viewer.search;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
@@ -22,6 +23,7 @@ public class SearchResult implements Comparable<SearchResult> {
     private final String startPageLabel;
     private final String thumbnailURL;
     private final String thumbnailOrientation;
+
     private final List<String> snippets;
     private final int score; // how relevant is this result, used for ordering.
 
@@ -125,6 +127,21 @@ public class SearchResult implements Comparable<SearchResult> {
             .hash(title, type, fileId, startPage, startPageLabel, thumbnailURL,
                 thumbnailOrientation,
                 snippets, score);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("title", title)
+            .add("type", type)
+            .add("fileId", fileId)
+            .add("startPage", startPage)
+            .add("startPageLabel", startPageLabel)
+            .add("thumbnailURL", thumbnailURL)
+            .add("thumbnailOrientation", thumbnailOrientation)
+            .add("snippets", snippets)
+            .add("score", score)
+            .toString();
     }
 }
 

--- a/src/main/java/ulcambridge/foundations/viewer/search/SearchResult.java
+++ b/src/main/java/ulcambridge/foundations/viewer/search/SearchResult.java
@@ -1,6 +1,10 @@
 package ulcambridge.foundations.viewer.search;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nullable;
 
 /**
  * Holds information for an individual search result. Item id can be used to
@@ -11,28 +15,35 @@ import java.util.List;
  */
 public class SearchResult implements Comparable<SearchResult> {
 
-    private String title;
-    private String type;
-    private String fileId;
-    private int startPage;
-    private String startPageLabel;
-    private String thumbnailURL;
-    private String thumbnailOrientation;
-    private List<String> snippets;
-    private int score; // how relevant is this result, used for ordering.
+    private final String title;
+    private final String type;
+    private final String fileId;
+    private final int startPage;
+    private final String startPageLabel;
+    private final String thumbnailURL;
+    private final String thumbnailOrientation;
+    private final List<String> snippets;
+    private final int score; // how relevant is this result, used for ordering.
 
     // DocHits for all the matches found for this item.
     // private List<DocHit> docHits = new ArrayList<DocHit>();
 
     public SearchResult(String title, String fileId, int startPage,
-            String startPageLabel, List<String> snippets,
-            int score, String type, String thumbnailURL, String thumbnailOrientation) {
+            String startPageLabel, Iterable<String> snippets,
+            int score, String type, @Nullable String thumbnailURL, @Nullable String thumbnailOrientation) {
+
+        Preconditions.checkNotNull(title);
+        Preconditions.checkNotNull(fileId);
+        Preconditions.checkNotNull(startPageLabel);
+        Preconditions.checkNotNull(snippets);
+        Preconditions.checkNotNull(type);
 
         this.title = title;
         this.fileId = fileId;
         this.startPage = startPage;
         this.startPageLabel = startPageLabel;
-        this.snippets = snippets;
+        this.snippets = ImmutableList.copyOf(snippets);
+        this.snippets.forEach(Preconditions::checkNotNull);
         this.score = score;
         this.type = type;
         this.thumbnailURL = thumbnailURL;
@@ -90,20 +101,30 @@ public class SearchResult implements Comparable<SearchResult> {
         return thumbnailOrientation;
     }
 
-    /**
-     * Search Results are considered the same if they have the same ID. So are
-     * about the same book. There should be only one SearchResult object per
-     * item (book).
-     */
-    /*
-     * @Override public boolean equals(Object o) { if (o instanceof
-     * SearchResult) { SearchResult r = (SearchResult) o; return this.id ==
-     * r.id; } return false; }
-     *
-     * @Override public int hashCode(Object o) { if (o instanceof SearchResult)
-     * { SearchResult r = (SearchResult) o; return this.id == r.id; } return
-     * false; }
-     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SearchResult that = (SearchResult) o;
+        return startPage == that.startPage && score == that.score && title.equals(that.title)
+            && type
+            .equals(that.type) && fileId.equals(that.fileId) && startPageLabel
+            .equals(that.startPageLabel)
+            && Objects.equals(thumbnailURL, that.thumbnailURL) && Objects
+            .equals(thumbnailOrientation, that.thumbnailOrientation) && snippets
+            .equals(that.snippets);
+    }
 
+    @Override
+    public int hashCode() {
+        return Objects
+            .hash(title, type, fileId, startPage, startPageLabel, thumbnailURL,
+                thumbnailOrientation,
+                snippets, score);
+    }
 }
 

--- a/src/main/java/ulcambridge/foundations/viewer/search/XTFSearch.java
+++ b/src/main/java/ulcambridge/foundations/viewer/search/XTFSearch.java
@@ -1,5 +1,13 @@
 package ulcambridge.foundations.viewer.search;
 
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -12,14 +20,6 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import ulcambridge.foundations.viewer.forms.SearchForm;
-import ulcambridge.foundations.viewer.model.Properties;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 @Component
 @Profile("!test")
@@ -295,6 +295,16 @@ public class XTFSearch implements Search {
             results, facetGroups, "");
     }
 
+    private static int tryParseInt(String value, int _default, String itemId) {
+        try {
+            return Integer.parseInt(value);
+        }
+        catch(NumberFormatException e) {
+            LOG.error("Error in item ID {}: Unable to parse value as an int: '{}'", itemId, value);
+            return _default;
+        }
+    }
+
     /**
      * Creates a new SearchResult from the given Node.
      */
@@ -303,7 +313,7 @@ public class XTFSearch implements Search {
         String title = "";
         String id = "";
         int score = -1;
-        int startPage = 0;
+        int startPage = 1;
         String startPageLabel = "";
         List<String> snippets = new ArrayList<>();
         String itemType = "bookormanuscript"; // default
@@ -312,32 +322,24 @@ public class XTFSearch implements Search {
 
         // look at all the child tags
         if ("docHit".equals(node.getNodeName())) {
-
             // META Search Info.
-            final Element meta = (Element) node.getElementsByTagName("meta").item(0);
+            final Optional<Element> meta = Optional.ofNullable((Element) node.getElementsByTagName("meta").item(0));
 
-            title = getValueInHTML(meta.getElementsByTagName("title").item(0));
-            id = getValueInText(meta.getElementsByTagName("fileID").item(0));
+            title = getValueInHTML(meta.map(m -> m.getElementsByTagName("title").item(0)).orElse(null));
+            id = getValueInText(
+                meta.map(m -> m.getElementsByTagName("fileID").item(0)).orElse(null))
+                .replaceAll("\\s+", "");
 
-            id = id.replaceAll("\\s+", ""); // remove whitespace
+            score = tryParseInt(node.getAttribute("score"), -1, id);
 
-            score = Integer.parseInt(node.getAttribute("score"));
+            startPage = tryParseInt(meta.map(m -> m.getElementsByTagName("startPage").item(0))
+                .map(Node::getFirstChild)
+                .map(Node::getTextContent)
+                .orElse(""), 1, id);
 
-            final String startPageString = meta.getElementsByTagName("startPage")
-                .item(0).getFirstChild().getTextContent();
-
-            try {
-                startPage = Integer.parseInt(startPageString);
-            }
-            catch(NumberFormatException e) {
-                // TODO Send email to dev team regarding incorrect data format
-                LOG.error("Error in item ID {}: Unable to parse value as an int: '{}' (Doc title: '{}')",
-                        id, startPageString, title);
-                startPage = 1;
-            }
-
-            startPageLabel = node.getElementsByTagName("startPageLabel")
-                .item(0).getTextContent();
+            startPageLabel = Optional.ofNullable(
+                node.getElementsByTagName("startPageLabel").item(0))
+                .map(Node::getTextContent).orElse("");
 
             final NodeList snippetNodes = node.getElementsByTagName("snippet");
 
@@ -346,19 +348,14 @@ public class XTFSearch implements Search {
                 snippets.add(getValueInHTML(snippetNode));
             }
 
-            // itemType
-            if (node.getElementsByTagName("itemType").item(0)!=null) {
-                itemType = getValueInText(node.getElementsByTagName("itemType").item(0));
-            }
+            itemType = Optional.ofNullable(node.getElementsByTagName("itemType").item(0))
+                .map(this::getValueInText).filter(s -> s.length() > 0).orElse(itemType);
 
-            // Thumbnail
-            if (node.getElementsByTagName("thumbnailUrl").item(0)!=null) {
-                thumbnailURL = getValueInText(node.getElementsByTagName("thumbnailUrl").item(0));
-            }
+            thumbnailURL = Optional.ofNullable(node.getElementsByTagName("thumbnailUrl").item(0))
+                .map(this::getValueInText).filter(s -> s.length() > 0).orElse(null);
 
-            if (node.getElementsByTagName("thumbnailOrientation").item(0)!=null) {
-                thumbnailOrientation = getValueInText(node.getElementsByTagName("thumbnailOrientation").item(0));
-            }
+            thumbnailOrientation = Optional.ofNullable(node.getElementsByTagName("thumbnailOrientation").item(0))
+                .map(this::getValueInText).filter(s -> s.length() > 0).orElse(null);
         }
 
         return new SearchResult(title, id, startPage, startPageLabel,
@@ -372,7 +369,10 @@ public class XTFSearch implements Search {
      * @param node
      * @return
      */
-    public String getValueInText(final Node node) {
+    public String getValueInText(final @Nullable Node node) {
+        if(node == null) {
+            return "";
+        }
 
         if (node.getNodeType() == Node.TEXT_NODE) {
             if ("term".equals(node.getParentNode().getNodeName())) {

--- a/src/test/java/ulcambridge/foundations/viewer/search/SearchResultTest.java
+++ b/src/test/java/ulcambridge/foundations/viewer/search/SearchResultTest.java
@@ -1,15 +1,15 @@
 package ulcambridge.foundations.viewer.search;
 
-import org.junit.Test;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
+import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.truth.Truth;
+import java.net.URI;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
-
-import java.net.URI;
-
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
 
 /**
  * Unit test
@@ -43,5 +43,31 @@ public class SearchResultTest {
         assertEquals(1, result.getStartPage());
         assertEquals("front cover", result.getStartPageLabel());
         assertEquals(1, result.getSnippets().size());
+    }
+
+    private static SearchResult newSearchResult(String title) {
+        return new SearchResult(title, "", 0, "", ImmutableList.of(), -1, "", null, null);
+    }
+
+    @Test
+    public void testEqualsIsTrueForDistinctMatchingObjects() {
+        Truth.assertThat(newSearchResult("foo")).isEqualTo(newSearchResult("foo"));
+    }
+
+    @Test
+    public void testEqualsIsFalseForDistinctNonMatchingObjects() {
+        Truth.assertThat(newSearchResult("foo")).isNotEqualTo(newSearchResult("bar"));
+    }
+
+    @Test
+    public void testHashCodeIsEqualForMatchingObjects() {
+        Truth.assertThat(newSearchResult("foo").hashCode())
+            .isEqualTo(newSearchResult("foo").hashCode());
+    }
+
+    @Test
+    public void testHashCodeIsNotEqualForNonMatchingObjects() {
+        Truth.assertThat(newSearchResult("foo").hashCode())
+            .isNotEqualTo(newSearchResult("bar").hashCode());
     }
 }

--- a/src/test/java/ulcambridge/foundations/viewer/search/XTFSearchTest.java
+++ b/src/test/java/ulcambridge/foundations/viewer/search/XTFSearchTest.java
@@ -1,15 +1,20 @@
 package ulcambridge.foundations.viewer.search;
 
-import org.junit.Test;
-import org.w3c.dom.Document;
-import ulcambridge.foundations.viewer.forms.SearchForm;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+import static ulcambridge.foundations.viewer.testing.XMLTesting.getTestXml;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
+import com.google.common.collect.ImmutableList;
 import java.net.URI;
 import java.util.HashMap;
-
-import static org.junit.Assert.assertEquals;
+import java.util.stream.Collectors;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import ulcambridge.foundations.viewer.forms.SearchForm;
+import ulcambridge.foundations.viewer.testing.XMLTesting;
 
 public class XTFSearchTest {
     @Test
@@ -64,7 +69,27 @@ public class XTFSearchTest {
             }
             return null;
         }
-
     }
 
+    @Test
+    public void createSearchResultParsesValidDocHit() {
+        Element docHit = (Element)getTestXml(this, "docHit.xml")
+            .getElementsByTagName("docHit").item(0);
+
+        SearchResult result = new XTFSearch(URI.create("http://example")).createSearchResult(docHit);
+
+        assertThat(XMLTesting.normaliseSpace(result.getTitle())).isEqualTo(
+            "Letter from <b>Joseph</b> <b>Dalton</b> <b>Hooker</b> to C. R. Darwin [c. April 1851]");
+        assertThat(result.getType()).isEqualTo("example-type");
+        assertThat(result.getFileId()).isEqualTo("MS-DAR-00100-00164");
+        assertThat(result.getStartPage()).isEqualTo(1);
+        assertThat(result.getStartPageLabel()).isEqualTo("164r");
+        assertThat(result.getSnippets().stream()
+            .map(XMLTesting::normaliseSpace)
+            .collect(Collectors.toList())
+        ).isEqualTo(ImmutableList.of(
+            "Letter from <b>Joseph</b> <b>Dalton</b> <b>Hooker</b> to C. R. Darwin [c. April",
+            "<b>Hooker</b> , <b>Joseph</b> <b>Dalton</b>"
+        ));
+    }
 }

--- a/src/test/java/ulcambridge/foundations/viewer/search/XTFSearchTest.java
+++ b/src/test/java/ulcambridge/foundations/viewer/search/XTFSearchTest.java
@@ -8,9 +8,14 @@ import com.google.common.collect.ImmutableList;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import ulcambridge.foundations.viewer.forms.SearchForm;
@@ -91,5 +96,25 @@ public class XTFSearchTest {
             "Letter from <b>Joseph</b> <b>Dalton</b> <b>Hooker</b> to C. R. Darwin [c. April",
             "<b>Hooker</b> , <b>Joseph</b> <b>Dalton</b>"
         ));
+    }
+
+    @ParameterizedTest
+    @MethodSource("emptyDocHits")
+    public void createSearchResultHandlesMissingResultData(Element docHitWithMissingData, SearchResult expected) throws ParserConfigurationException {
+        XTFSearch xtf = new XTFSearch(URI.create("http://example/"));
+        assertThat(xtf.createSearchResult(docHitWithMissingData)).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> emptyDocHits() {
+        Document doc = getTestXml(XTFSearchTest.class, "docHitsWithMissingData.xml");
+        Element docHit1 = (Element)doc.getElementsByTagName("docHit").item(0);
+        Element docHit2 = (Element)doc.getElementsByTagName("docHit").item(1);
+        Element docHit3 = (Element)doc.getElementsByTagName("docHit").item(2);
+        SearchResult empty = new SearchResult("", "", 1, "", ImmutableList.of(), -1, "bookormanuscript", null, null);
+        return Stream.of(
+            Arguments.of(docHit1, empty),
+            Arguments.of(docHit2, empty),
+            Arguments.of(docHit3, empty)
+        );
     }
 }

--- a/src/test/java/ulcambridge/foundations/viewer/testing/XMLTesting.java
+++ b/src/test/java/ulcambridge/foundations/viewer/testing/XMLTesting.java
@@ -1,0 +1,33 @@
+package ulcambridge.foundations.viewer.testing;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+public class XMLTesting {
+    private XMLTesting() {}
+
+    public static Document getTestXml(Object context, String path) {
+        Class<?> contextClass = context instanceof Class ? (Class<?>)context : context.getClass();
+        InputStream s = contextClass.getResourceAsStream(path);
+        if(s == null)
+            throw new IllegalArgumentException(String.format(
+                "Failed to load test XML document: Resource file not found at path: \"%s\", "
+                    + "context: %s", path, contextClass));
+        try {
+            return DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(s);
+        } catch (SAXException | IOException | ParserConfigurationException e) {
+            throw new RuntimeException(String.format(
+                "Failed to load test XML document at path: \"%s\", "
+                    + "context: %s: %s", path, contextClass, e.getMessage()), e);
+        }
+    }
+
+    public static String normaliseSpace(String s) {
+        return s.trim().replaceAll("\\s+", " ");
+    }
+}

--- a/src/test/resources/ulcambridge/foundations/viewer/search/docHit.xml
+++ b/src/test/resources/ulcambridge/foundations/viewer/search/docHit.xml
@@ -1,0 +1,50 @@
+<crossQueryResult queryTime="0.014" totalDocs="1547" startDoc="1" endDoc="20">
+    <docHit rank="1" path="index-cudl-tagging:MS-DAR-00100-00164.json" score="100" totalHits="0" subDocument="DOCUMENT">
+        <meta>
+            <display>dynaxml</display>
+            <fileID>MS-DAR-00100-00164</fileID>
+            <startPageLabel>164r</startPageLabel>
+            <startPage>1</startPage>
+            <itemType>example-type</itemType>
+            <title display="false" displayForm="Letter from Joseph Dalton Hooker to C. R. Darwin   [c. April 1851]">
+                <snippet rank="1" score="100">
+                    Letter from
+                    <hit>
+                        <term>Joseph</term>
+                        <term>Dalton</term>
+                        <term>Hooker</term>
+                    </hit>
+                    to C. R. Darwin   [c. April
+                </snippet>
+                1851]
+            </title>
+            <sort-title>letter from joseph dalton hooker to c r darwin c april 1851</sort-title>
+            <nameFullForm>Darwin, Charles Robert</nameFullForm>
+            <nameFullForm>
+                <snippet rank="1" score="100">
+                    <hit>
+                        <term>Hooker</term>
+                        ,
+                        <term>Joseph</term>
+                        <term>Dalton</term>
+                    </hit>
+                </snippet>
+            </nameFullForm>
+            <languageCode>eng</languageCode>
+            <languageString>English</languageString>
+            <physicalLocation display="true" displayForm="Cambridge University Library">Cambridge University Library</physicalLocation>
+            <shelfLocator display="true" displayForm="MS DAR 100: 164">MS DAR 100: 164</shelfLocator>
+            <search-shelfLocator>MS DAR 100: 164</search-shelfLocator>
+            <eventCreationDateStart>1851-04-01</eventCreationDateStart>
+            <eventCreationDateEnd>1851-04-01</eventCreationDateEnd>
+            <eventCreationDateDisplay>[c. Apr 1851]</eventCreationDateDisplay>
+            <placeFullForm>Kew</placeFullForm>
+            <sort-year>1851</sort-year>
+            <year>1851-1851</year>
+            <facet-date>1800s C.E.</facet-date>
+            <thumbnailUrl>MS-DAR-00100-000-00341</thumbnailUrl>
+            <thumbnailOrientation>portrait</thumbnailOrientation>
+            <facet-collection>Darwin-Hooker Letters</facet-collection>
+        </meta>
+    </docHit>
+</crossQueryResult>

--- a/src/test/resources/ulcambridge/foundations/viewer/search/docHitsWithMissingData.xml
+++ b/src/test/resources/ulcambridge/foundations/viewer/search/docHitsWithMissingData.xml
@@ -1,0 +1,32 @@
+<examples>
+    <docHit rank="1" path="index-cudl-tagging:MS-DAR-00100-00164.json" subDocument="DOCUMENT"></docHit>
+    <docHit rank="1" path="index-cudl-tagging:MS-DAR-00100-00164.json" score="" totalHits="" subDocument="DOCUMENT"></docHit>
+
+    <docHit rank="1" path="index-cudl-tagging:MS-DAR-00100-00164.json" subDocument="DOCUMENT">
+        <meta>
+            <display/>
+            <fileID/>
+            <startPageLabel/>
+            <startPage/>
+            <itemType/>
+            <title/>
+            <sort-title/>
+            <nameFullForm/>
+            <languageCode/>
+            <languageString/>
+            <physicalLocation/>
+            <shelfLocator/>
+            <search-shelfLocator/>
+            <eventCreationDateStart/>
+            <eventCreationDateEnd/>
+            <eventCreationDateDisplay/>
+            <placeFullForm/>
+            <sort-year/>
+            <year/>
+            <facet-date/>
+            <thumbnailUrl/>
+            <thumbnailOrientation/>
+            <facet-collection/>
+        </meta>
+    </docHit>
+</examples>


### PR DESCRIPTION
`XTFSearch.createSearchResult()` now handles nulls from accessing missing DOM data.

This fixes #1.