### PR TITLE
fix: update junit and guava to fix vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>2.2.4.RELEASE</version>
+                <version>2.4.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -286,7 +286,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -598,7 +597,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>28.2-jre</version>
+            <version>30.1.1-jre</version>
         </dependency>
 
         <!-- Apache Jena -->


### PR DESCRIPTION
Dependabot warned about vulnerabilities in two.

There's another outstanding issue for one of the dependencies of the bundled equatorie code which I'm not fixing here: https://github.com/cambridge-collection/cudl-viewer/security/dependabot/src/main/misc/equatorie-src/package.json/uglify-js/open