### PR TITLE
Fix social media link preview images

### DIFF
--- a/src/main/java/ulcambridge/foundations/viewer/utils/IIIFUtils.java
+++ b/src/main/java/ulcambridge/foundations/viewer/utils/IIIFUtils.java
@@ -1,0 +1,59 @@
+package ulcambridge.foundations.viewer.utils;
+
+import org.springframework.web.util.UriComponentsBuilder;
+
+/**
+ * Class for utilities related to calling IIIF APIs.
+ *
+ */
+public class IIIFUtils {
+
+    /**
+     * Calculate the IIIF request parameters needed to make a maximal centre cut of an original image
+     * with the output image sized to match requested dimensions.
+     *
+     * @param imgWidth Original image width
+     * @param imgHeight Original image height
+     * @param reqWidth Requested image width
+     * @param reqHeight Requested image height
+     * @return The IIIF Image API 2.0 URL request parameters
+     */
+    public static String getCentreCutIIIFRequestParams(int imgWidth, int imgHeight, int reqWidth, int reqHeight) {
+        int regionX = 0, regionY = 0, regionW, regionH, sizeW, sizeH;
+
+        sizeW = reqWidth;
+        sizeH = reqHeight;
+
+        float imgRatio = (float) imgHeight / imgWidth;
+        float reqRatio = (float) reqHeight / reqWidth;
+
+        if (imgRatio > reqRatio) {
+            // Original image is more portrait relative to requested image dimensions
+            regionW = imgWidth;
+            regionH = Math.round(regionW * reqRatio);
+            regionY = (imgHeight - regionH) / 2;
+
+        } else if (imgRatio < reqRatio) {
+            // Original image is more landscape relative to requested image dimensions
+            regionH = imgHeight;
+            regionW = Math.round(regionH / reqRatio);
+            regionX = (imgWidth - regionW) / 2;
+
+        } else {
+            // Both images probably square, so serve whole original image
+            regionW = imgWidth;
+            regionH = imgHeight;
+        }
+
+        String region = String.format("/%d,%d,%d,%d", regionX, regionY, regionW, regionH);
+        String size = String.format("/%d,%d", sizeW, sizeH);
+
+        return UriComponentsBuilder.newInstance()
+            .path(region).path(size)
+            .path("/0").path("/default.jpg")
+            .build()
+            .encode()
+            .toUriString();
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,9 +11,9 @@ ui.options.image.downloadSizes={'Default': 2000}
 ui.options.buttons.about.pdfSinglePage=true
 ui.options.buttons.about.pdfFullDocument=true
 
-# Specify request parameters for IIIF images to offer as social media link previews of an item page
+# Specify dimensions of IIIF images for social media link previews in map of form {'width': 1200, 'height': 630}
 # If nothing specified, og:image and twitter:image in page metadata will be default thumbnail size instead
-social.options.image.iiifRequestParams="/pct:0,25,100,50/1200,630/0/default.jpg"
+social.options.image.dimensions={'width': 1200, 'height': 630}
 
 mirador.options.default.config=mirador/default-config.json
 mirador.options.default.companionWindows=0

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,6 +11,10 @@ ui.options.image.downloadSizes={'Default': 2000}
 ui.options.buttons.about.pdfSinglePage=true
 ui.options.buttons.about.pdfFullDocument=true
 
+# Specify request parameters for IIIF images to offer as social media link previews of an item page
+# If nothing specified, og:image and twitter:image in page metadata will be default thumbnail size instead
+social.options.image.iiifRequestParams="/pct:0,25,100,50/1200,630/0/default.jpg"
+
 mirador.options.default.config=mirador/default-config.json
 mirador.options.default.companionWindows=0
 mirador.options.default.companionWindows.align=

--- a/src/main/webapp/WEB-INF/jsp/document.jsp
+++ b/src/main/webapp/WEB-INF/jsp/document.jsp
@@ -11,6 +11,7 @@
 <c:set var="title" value="${organisationalCollection.title} : ${item.title}"/>
 <c:set var="authors" value="${cudlfn:join(item.authorNames, ', ')}"/>
 <c:set var="iiifManifestURL" value="${rootURL}/iiif/${item.id}"/>
+<c:set var="fullThumbnailURL" value="${imageServer}/${thumbnailURL}"/>
 
 <cudl:base-page title="${title}">
     <jsp:attribute name="head">
@@ -46,10 +47,10 @@
                 </c:if>
 
                 <!-- Image URI (Thumbnail) -->
-                <cudl:meta property="schema:image" content="${thumbnailURL}" />
-                <cudl:meta property="og:image" content="http://cudl.lib.cam.ac.uk/images/index/carousel-treasures.jpg" />
-                <cudl:meta property="twitter:image" content="${thumbnailURL}" />
-                <cudl:meta property="schema:thumbnailUrl" content="${thumbnailURL}" />
+                <cudl:meta property="schema:image" content="${fullThumbnailURL}" />
+                <cudl:meta property="og:image" content="${fullThumbnailURL}" />
+                <cudl:meta property="twitter:image" content="${fullThumbnailURL}" />
+                <cudl:meta property="schema:thumbnailUrl" content="${fullThumbnailURL}" />
 
                 <cudl:meta property="og:site_name" content="Cambridge Digital Library" />
                 <cudl:meta property="twitter:creator" content="@camdiglib" />

--- a/src/main/webapp/WEB-INF/jsp/document.jsp
+++ b/src/main/webapp/WEB-INF/jsp/document.jsp
@@ -18,43 +18,40 @@
         <cudl:head-content pagetype="DOCUMENT"
                            viewport="width=device-width, maximum-scale=1, initial-scale=1">
             <jsp:attribute name="metaTags">
-                <!-- page metadata tags -->
-                <cudl:meta property="og:type" content="website"/>
-                <cudl:meta property="twitter:card" content="summary"/>
-
-                <!-- Item URI -->
-                <cudl:meta property="schema:url" content="${canonicalURL}" />
-                <cudl:meta property="og:url" content="${canonicalURL}" />
                 <link rel="canonical" href="${fn:escapeXml(canonicalURL)}" />
+                <cudl:meta name="keywords" content="${item['abstract']}" />
+                <cudl:meta name="description" content="${item['abstract']}" />
 
-                <!-- Item Title -->
+                <!-- Tags for search engines -->
+                <cudl:meta property="schema:url" content="${canonicalURL}" />
                 <cudl:meta property="schema:name rdfs:label dcterms:title" content="${title}"/>
-                <cudl:meta property="og:title" content="${title}"/>
-                <cudl:meta property="twitter:title" content="${title}"/>
-                <cudl:meta name="keywords" property="schema:keywords"
-                           content="${authors}" />
-
-                <!-- Item Description -->
-                <%-- Tomcat 7 seems to reserve the .abstract property... --%>
-                <c:if test="${fn:length(fn:trim(item['abstract'])) > 0}">
-                    <cudl:meta property="schema:description rdfs:comment dcterms:description"
-                               content="${item['abstract']}"/>
-                    <cudl:meta property="og:description" content="${item['abstract']}" />
-                    <cudl:meta property="twitter:description" content="${item['abstract']}" />
-                    <cudl:meta name="description" content="${item['abstract']}" />
-                    <cudl:meta property="schema:keywords" content="${item['abstract']}" />
-                    <cudl:meta name="keywords" content="${item['abstract']}" />
-                </c:if>
-
-                <!-- Image URI (Thumbnail) -->
+                <cudl:meta property="schema:keywords" name="keywords"  content="${authors}" />
+                <cudl:meta property="schema:keywords" content="${item['abstract']}" />
+                <cudl:meta property="schema:description rdfs:comment dcterms:description"
+                           content="${item['abstract']}"/>
                 <cudl:meta property="schema:image" content="${fullThumbnailURL}" />
-                <cudl:meta property="og:image" content="${fullThumbnailURL}" />
-                <cudl:meta property="twitter:image" content="${fullThumbnailURL}" />
                 <cudl:meta property="schema:thumbnailUrl" content="${fullThumbnailURL}" />
 
+                <!-- Tags for general social media, including Facebook -->
+                <cudl:meta property="og:url" content="${canonicalURL}" />
+                <cudl:meta property="og:type" content="website"/>
                 <cudl:meta property="og:site_name" content="Cambridge Digital Library" />
+                <cudl:meta property="og:title" content="${title}"/>
+                <cudl:meta property="og:description" content="${item['abstract']}" />
+                <cudl:meta property="og:image" content="${fullThumbnailURL}" />
+                <cudl:meta property="og:locale" content="en_GB"/>
+<%--                <cudl:meta property="og:image:width" content="1200"/>--%>
+<%--                <cudl:meta property="og:image:height" content="630"/>--%>
+
+                <!-- Tags for Twitter -->
+                <cudl:meta property="twitter:card" content="summary"/>
+<%--                <cudl:meta property="twitter:card" content="summary_large_image"/>--%>
+                <cudl:meta property="twitter:title" content="${title}"/>
+                <cudl:meta property="twitter:description" content="${item['abstract']}" />
+                <cudl:meta property="twitter:image" content="${fullThumbnailURL}" />
                 <cudl:meta property="twitter:creator" content="@camdiglib" />
                 <cudl:meta property="twitter:site" content="@camdiglib" />
+
             </jsp:attribute>
 
             <jsp:body>

--- a/src/main/webapp/WEB-INF/jsp/document.jsp
+++ b/src/main/webapp/WEB-INF/jsp/document.jsp
@@ -37,20 +37,34 @@
                 <cudl:meta property="og:type" content="website"/>
                 <cudl:meta property="og:site_name" content="Cambridge Digital Library" />
                 <cudl:meta property="og:title" content="${title}"/>
-                <cudl:meta property="og:description" content="${item['abstract']}" />
-                <cudl:meta property="og:image" content="${fullThumbnailURL}" />
+                <cudl:meta property="og:description" content="${item.abstractShort}" />
                 <cudl:meta property="og:locale" content="en_GB"/>
+                <c:choose>
+                    <c:when test="${socialIIIFUrl != null}">
+                        <cudl:meta property="og:image" content="${socialIIIFUrl}" />
 <%--                <cudl:meta property="og:image:width" content="1200"/>--%>
 <%--                <cudl:meta property="og:image:height" content="630"/>--%>
+                    </c:when>
+                    <c:otherwise>
+                        <cudl:meta property="og:image" content="${fullThumbnailURL}" />
+                    </c:otherwise>
+                </c:choose>
 
                 <!-- Tags for Twitter -->
-                <cudl:meta property="twitter:card" content="summary"/>
-<%--                <cudl:meta property="twitter:card" content="summary_large_image"/>--%>
                 <cudl:meta property="twitter:title" content="${title}"/>
-                <cudl:meta property="twitter:description" content="${item['abstract']}" />
-                <cudl:meta property="twitter:image" content="${fullThumbnailURL}" />
+                <cudl:meta property="twitter:description" content="${item.abstractShort}" />
                 <cudl:meta property="twitter:creator" content="@camdiglib" />
                 <cudl:meta property="twitter:site" content="@camdiglib" />
+                <c:choose>
+                    <c:when test="${socialIIIFUrl != null}">
+                        <cudl:meta property="twitter:card" content="summary_large_image"/>
+                        <cudl:meta property="twitter:image" content="${socialIIIFUrl}" />
+                    </c:when>
+                    <c:otherwise>
+                        <cudl:meta property="twitter:card" content="summary"/>
+                        <cudl:meta property="twitter:image" content="${fullThumbnailURL}" />
+                    </c:otherwise>
+                </c:choose>
 
             </jsp:attribute>
 

--- a/src/main/webapp/WEB-INF/jsp/document.jsp
+++ b/src/main/webapp/WEB-INF/jsp/document.jsp
@@ -42,8 +42,8 @@
                 <c:choose>
                     <c:when test="${socialIIIFUrl != null}">
                         <cudl:meta property="og:image" content="${socialIIIFUrl}" />
-<%--                <cudl:meta property="og:image:width" content="1200"/>--%>
-<%--                <cudl:meta property="og:image:height" content="630"/>--%>
+                        <cudl:meta property="og:image:width" content="${socialImageWidth}"/>
+                        <cudl:meta property="og:image:height" content="${socialImageHeight}"/>
                     </c:when>
                     <c:otherwise>
                         <cudl:meta property="og:image" content="${fullThumbnailURL}" />

--- a/src/test/java/ulcambridge/foundations/viewer/DocumentViewControllerTest.java
+++ b/src/test/java/ulcambridge/foundations/viewer/DocumentViewControllerTest.java
@@ -1,5 +1,6 @@
 package ulcambridge.foundations.viewer;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -42,6 +43,7 @@ public class DocumentViewControllerTest {
         URI rootUri = URI.create("http://testurl.testingisthebest.com:8080");
         URI iiifImageServer = URI.create("http://images.digital.library.example.com/iiif/");
         Optional<Map<String, String>> downloadSizes = Optional.empty();
+        Optional<String> socialIIIFParams = Optional.of("/pct:0,25,100,50/1200,630/0/default.jpg");
 
         MockHttpServletRequest req = new MockHttpServletRequest();
         req.setRequestURI("/view/" + ITEM_ID);
@@ -54,7 +56,8 @@ public class DocumentViewControllerTest {
             itemsDao,
             rootUri,
             iiifImageServer,
-            downloadSizes
+            downloadSizes,
+            socialIIIFParams
         );
 
         ModelAndView mDoc = c.handleRequest(ITEM_ID, req);
@@ -65,6 +68,10 @@ public class DocumentViewControllerTest {
         assertEquals("http://testurl.testingisthebest.com:8080/view/MS-ADD-04004", mDoc.getModelMap().get("canonicalURL"));
         assertNotNull(mDoc.getModelMap().get("downloadSizes"));
         assertEquals(new HashMap<>(), mDoc.getModelMap().get("downloadSizes"));
+        Assertions.assertNotNull(mDoc.getModelMap().get("socialIIIFUrl"));
+        Assertions.assertEquals(
+            "http://images.digital.library.example.com/iiif/MS-ADD-04004-000-00001.jp2/pct:0,25,100,50/1200,630/0/default.jpg",
+            mDoc.getModelMap().get("socialIIIFUrl"));
     }
 
 }

--- a/src/test/java/ulcambridge/foundations/viewer/DocumentViewControllerTest.java
+++ b/src/test/java/ulcambridge/foundations/viewer/DocumentViewControllerTest.java
@@ -43,7 +43,7 @@ public class DocumentViewControllerTest {
         URI rootUri = URI.create("http://testurl.testingisthebest.com:8080");
         URI iiifImageServer = URI.create("http://images.digital.library.example.com/iiif/");
         Optional<Map<String, String>> downloadSizes = Optional.empty();
-        Optional<String> socialIIIFParams = Optional.of("/pct:0,25,100,50/1200,630/0/default.jpg");
+        Optional<Map<String, String>> socialImageDimensions = Optional.empty();
 
         MockHttpServletRequest req = new MockHttpServletRequest();
         req.setRequestURI("/view/" + ITEM_ID);
@@ -57,7 +57,7 @@ public class DocumentViewControllerTest {
             rootUri,
             iiifImageServer,
             downloadSizes,
-            socialIIIFParams
+            socialImageDimensions
         );
 
         ModelAndView mDoc = c.handleRequest(ITEM_ID, req);
@@ -68,10 +68,7 @@ public class DocumentViewControllerTest {
         assertEquals("http://testurl.testingisthebest.com:8080/view/MS-ADD-04004", mDoc.getModelMap().get("canonicalURL"));
         assertNotNull(mDoc.getModelMap().get("downloadSizes"));
         assertEquals(new HashMap<>(), mDoc.getModelMap().get("downloadSizes"));
-        Assertions.assertNotNull(mDoc.getModelMap().get("socialIIIFUrl"));
-        Assertions.assertEquals(
-            "http://images.digital.library.example.com/iiif/MS-ADD-04004-000-00001.jp2/pct:0,25,100,50/1200,630/0/default.jpg",
-            mDoc.getModelMap().get("socialIIIFUrl"));
+        Assertions.assertNull(mDoc.getModelMap().get("socialImageDimensions"));
     }
 
 }

--- a/src/test/java/ulcambridge/foundations/viewer/model/Items.java
+++ b/src/test/java/ulcambridge/foundations/viewer/model/Items.java
@@ -1,14 +1,12 @@
 package ulcambridge.foundations.viewer.model;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.springframework.util.Assert;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 public final class Items {
     private Items() {}
@@ -34,6 +32,9 @@ public final class Items {
         );
 
         JSONObject json = new JSONObject();
+        JSONArray pages = new JSONArray();
+        pages.put(new JSONObject().put("IIIFImageURL", String.format("%s-000-00001.jp2", itemId)));
+        json.put("pages", pages);
 
         return new Item(
             itemId,

--- a/src/test/java/ulcambridge/foundations/viewer/utils/IIIFUtilsTest.java
+++ b/src/test/java/ulcambridge/foundations/viewer/utils/IIIFUtilsTest.java
@@ -1,0 +1,29 @@
+package ulcambridge.foundations.viewer.utils;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class IIIFUtilsTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        "4643,5715,500,1000, '/892,0,2858,5715/500,1000/0/default.jpg'", // Portrait original, portrait output
+        "4643,5715,1200,630, '/0,1638,4643,2438/1200,630/0/default.jpg'", // Portrait original, landscape output
+        "464,571,1200,630, '/0,163,464,244/1200,630/0/default.jpg'", // Small portrait original, large landscape output
+        "464,571,1200,630, '/0,163,464,244/1200,630/0/default.jpg'", // Small portrait original, large landscape output
+        "13397,2420,1200,630, '/4393,0,4610,2420/1200,630/0/default.jpg'", // Landscape original, landscape output
+        "13397,2420,500,1000, '/6093,0,1210,2420/500,1000/0/default.jpg'", // Landscape original, portrait output
+        "4789,4789,500,1000, '/1197,0,2395,4789/500,1000/0/default.jpg'", // Square original, portrait output
+        "4789,4789,1200,630, '/0,1137,4789,2514/1200,630/0/default.jpg'", // Square original, landscape output
+        "4789,4789,1000,1000, '/0,0,4789,4789/1000,1000/0/default.jpg'", // Square original, square output
+    })
+    public void getCentreCutIIIFRequestParams(int imgWidth, int imgHeight, int reqWidth, int reqHeight,
+                                              String expectedRequestParams) {
+        Assertions.assertEquals(expectedRequestParams,
+            IIIFUtils.getCentreCutIIIFRequestParams(imgWidth, imgHeight, reqWidth, reqHeight));
+
+    }
+
+
+}


### PR DESCRIPTION
This PR fixes a long-standing bug whereby when pasting a link to a CUDL item page into Facebook and other social media platforms shows a fixed image unrelated to the item content; meanwhile Twitter is offered nothing at all. See example problem at: https://socialsharepreview.com/?url=https://cudl.lib.cam.ac.uk/view/PH-CAVENDISH-P-00001/1

Originally, the functionality was supposed to offer a thumbnail image of the item page. This functionality has been fixed and retained as a fallback, but the PR also enhances the link preview images by offering a high-resolution image from the IIIF server, with dimensions more appropriate to contemporary social media requirements. See some recommendations here: https://placid.app/blog/how-to-get-large-facebook-twitter-link-thumbnails (Also the FB/Twitter docs)

Here are some example images it would serve:
https://images.lib.cam.ac.uk/iiif/MS-FF-00001-00023-000-00050.jp2/0,2750,8000,4200/1200,630/0/default.jpg
https://images.lib.cam.ac.uk/iiif/MS-II-00004-00026-000-00063.jp2/0,2906,5258,2760/1200,630/0/default.jpg
https://images.lib.cam.ac.uk/iiif/MS-ADD-00269-000-00026.jp2/0,3249,6365,3342/1200,630/0/default.jpg
https://images.lib.cam.ac.uk/iiif/MS-MAPS-MS-PLANS-00004-000-00001.jp2/0,1300,12614,6622/1200,630/0/default.jpg
https://images.lib.cam.ac.uk/iiif/MS-ADD-03958-001-00001.jp2/0,1710,4421,2321/1200,630/0/default.jpg
https://images.lib.cam.ac.uk/iiif/PH-GEOGRAPHY-35KAB-00034-000-00001.jp2/0,451,7235,3798/1200,630/0/default.jpg
https://images.lib.cam.ac.uk/iiif/MS-ADD-01643-000-00004.jp2/4741,0,4693,2464/1200,630/0/default.jpg
https://images.lib.cam.ac.uk/iiif/MS-FJ-00120-00036-000-00001.jp2/0,6619,28609,15020/1200,630/0/default.jpg
https://images.lib.cam.ac.uk/iiif/MS-ADD-00431-000-00001.jp2/0,1605,17536,9206/1200,630/0/default.jpg
https://images.lib.cam.ac.uk/iiif/MS-RCMS-00352-000-00001.jp2/0,2756,5622,2952/1200,630/0/default.jpg
https://images.lib.cam.ac.uk/iiif/MS-LEWIS-00002-000-00001.jp2/0,1453,5354,2811/1200,630/0/default.jpg
https://images.lib.cam.ac.uk/iiif/MS-ORCS-00008-00002-000-00001.jp2/0,631,7884,4139/1200,630/0/default.jpg

It is necessary to write a new CUDL-Viewer functionality rather than do this in CUDL-Viewer-UI because the Facebook and Twitter bots do not run JavaScript. The image URLs must be available on basic page load.

* Basic fix for adding back the thumbnail URLs and tidying the metadata tags. This is the minimum fix needed.
* Configure social media image URLs by giving explicit IIIF params. This is not an optimal solution due to undesirable image squashing, so it is superceded by:
* Configure social media image URLs by just specifying an optimal width and height. The IIIF request parameters are calculated on a per image basis and a centre cut of the image of the specified dimensions is returned. Social media platforms are likely to change their minds periodically about what they want. This way you can change it whenever you need to without touching the code.

Thank you for getting this far! Would particularly welcome comments on whether a private method in `DocumentViewController` for `getCentreCutIIIFRequestParams()` is really the best place for it. I would want to write some paramaterised tests but that's not easy to do right now.