### PR TITLE
Add crumbtrail and page title

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/about.jsp
+++ b/src/main/webapp/WEB-INF/jsp/about.jsp
@@ -14,6 +14,7 @@
 
     <jsp:body>
         <cudl:nav activeMenuIndex="${4}" displaySearch="true" subtitle="Introducing the Cambridge Digital Library"/>
+        <cudl:page-title title="Introducing the Cambridge Digital Library" additionalClasses="campl-wrap clearfix" />
         <div class="campl-row campl-content campl-recessed-content">
             <div class="campl-wrap clearfix">
                 <cudl:about-nav/>

--- a/src/main/webapp/WEB-INF/jsp/collection-organisation.jsp
+++ b/src/main/webapp/WEB-INF/jsp/collection-organisation.jsp
@@ -30,20 +30,6 @@
             <div class="campl-wrap clearfix">
                 <div class="campl-column7  campl-main-content" id="content">
                     <div id="summaryDiv" class="campl-content-container">
-
-                        <%-- If this collection has a parent show breadcrumb --%>
-                        <c:if test="${fn:length(collection.parentCollectionId) > 0}">
-                            <c:set var="parentCollection" value="${cudlfn:getCollection(collectionFactory, collection.parentCollectionId)}"/>
-
-                            <div class="campl-breadcrumb" id="subcollection-breadcrumb">
-                                <ul class="campl-unstyled-list campl-horizontal-navigation clearfix">
-                                    <li><a href="${fn:escapeXml(parentCollection.URL)}"><c:out value="${parentCollection.title}"/></a></li>
-                                    <li>/</li>
-                                    <li><p class="campl-current"><c:out value="${collection.title}"/></p></li>
-                                </ul>
-                            </div>
-                        </c:if>
-
                         <%-- FIXME: Make a custom tag for resolving external HTML of different types w/ collection attribute/param --%>
                         <c:catch var="importException">
                             <c:import charEncoding="UTF-8" url="${contentHTMLURL}/${collection.summary}"/>

--- a/src/main/webapp/WEB-INF/jsp/collection-organisation.jsp
+++ b/src/main/webapp/WEB-INF/jsp/collection-organisation.jsp
@@ -24,10 +24,11 @@
     </jsp:attribute>
 
     <jsp:body>
-        <cudl:nav activeMenuIndex="${1}" displaySearch="true" title="Browse our collections"/>
+        <cudl:nav activeMenuIndex="${1}" displaySearch="true" title="Browse our collections" collection="${collection}"/>
 
         <div class="campl-row campl-content campl-recessed-content">
             <div class="campl-wrap clearfix">
+                <cudl:page-title title="${collection.title}"/>
                 <div class="campl-column7  campl-main-content" id="content">
                     <div id="summaryDiv" class="campl-content-container">
                         <%-- FIXME: Make a custom tag for resolving external HTML of different types w/ collection attribute/param --%>

--- a/src/main/webapp/WEB-INF/jsp/collection-parent.jsp
+++ b/src/main/webapp/WEB-INF/jsp/collection-parent.jsp
@@ -18,11 +18,11 @@
     </jsp:attribute>
 
     <jsp:body>
-        <cudl:nav activeMenuIndex="${1}" displaySearch="true" subtitle="${collection.title}"/>
+        <cudl:nav activeMenuIndex="${1}" displaySearch="true" title="Browse our collections"/>
 
         <div class="campl-row campl-content campl-recessed-content">
             <div class="campl-wrap clearfix">
-
+                <cudl:page-title title="${collection.title}"/>
                 <!-- side nav -->
                 <div class="campl-column3">
                     <div class="campl-tertiary-navigation">

--- a/src/main/webapp/WEB-INF/jsp/collection-virtual.jsp
+++ b/src/main/webapp/WEB-INF/jsp/collection-virtual.jsp
@@ -27,6 +27,7 @@
 
                     <div class="campl-column12  campl-main-content campl-content-container" id="content">
                         <div id="summaryDiv" class="virtual_collection_summary">
+                            <cudl:page-title title="${collection.title}"/>
                             <c:catch var="importException">
                                 <c:import charEncoding="UTF-8" url="${contentHTMLURL}/${collection.summary}"/>
                             </c:catch>

--- a/src/main/webapp/WEB-INF/jsp/collections.jsp
+++ b/src/main/webapp/WEB-INF/jsp/collections.jsp
@@ -8,15 +8,17 @@
 <%@taglib prefix="cudl" tagdir="/WEB-INF/tags" %>
 <%@taglib prefix="cudlfn" uri="/WEB-INF/cudl-functions.tld" %>
 
+<c:set var="pagetitle" value="Browse our collections"/>
+
 <cudl:generic-page pagetype="STANDARD" title="${collection.title}">
     <jsp:body>
-        <cudl:nav activeMenuIndex="${1}" displaySearch="true" title="Browse our collections"/>
+        <cudl:nav activeMenuIndex="${1}" displaySearch="true" title="${pagetitle}"/>
 
         <div class="campl-row campl-content campl-recessed-content">
             <div class="campl-wrap clearfix">
                 <div class="campl-column12  campl-main-content" id="content">
                     <div id="collectionsDiv">
-                        <h2>Browse our collections</h2>
+                        <cudl:page-title title="${pagetitle}"/>
                         <c:forEach items="${collections}" var="c">
                             <c:if test="${empty c.parentCollectionId}">
                                 <div class="campl-column4">

--- a/src/main/webapp/WEB-INF/tags/crumbtrail.tag
+++ b/src/main/webapp/WEB-INF/tags/crumbtrail.tag
@@ -1,0 +1,39 @@
+<%@tag description="The CUDL crumbtrail" pageEncoding="UTF-8" trimDirectiveWhitespaces="true" %>
+<%@attribute name="title" required="false" type="java.lang.String" %>
+<%@attribute name="subtitle" required="false" type="java.lang.String" %>
+<%@attribute name="collection" required="false" type="java.lang.Object" %>
+
+<%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@taglib prefix="sec" uri="http://www.springframework.org/security/tags" %>
+<%@taglib prefix="cudl" tagdir="/WEB-INF/tags" %>
+<%@taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@taglib prefix="cudlfn" uri="/WEB-INF/cudl-functions.tld" %>
+
+<c:set var="defaultTitle" value="Cambridge Digital Library"/>
+
+<c:set var = "uriArray" value = "${fn:split(requestScope['javax.servlet.forward.request_uri'],'/,')}"/>
+<c:if test="${fn:length(uriArray) gt 0}">
+    <div class="container crumbtrail">
+        <a href="/">
+            <i class="fa fa-home" title="Home" aria-hidden="true"></i>
+            <span class="sr-only">Home</span>
+        </a>
+        >
+        <c:choose>
+            <c:when test="${fn:length(uriArray) == 1}">
+                ${(not empty title) ? title : subtitle}
+            </c:when>
+            <c:when test="${fn:length(uriArray) > 1 && uriArray[0] == 'collections'}">
+                <a href="/${uriArray[0]}/">${(not empty title) ? title : subtitle}</a>
+                <c:if test="${fn:length(collection.parentCollectionId) > 0}">
+                    <c:set var="parentCollection" value="${cudlfn:getCollection(collectionFactory, collection.parentCollectionId)}"/>
+                    >
+                    <a href="${fn:escapeXml(parentCollection.URL)}">
+                        <c:out value="${parentCollection.title}"/></a>
+                </c:if>
+                <c:if test="${not empty collection}"> > ${collection.title}</c:if>
+            </c:when>
+            <c:otherwise/>
+        </c:choose>
+    </div>
+</c:if>

--- a/src/main/webapp/WEB-INF/tags/nav.tag
+++ b/src/main/webapp/WEB-INF/tags/nav.tag
@@ -3,10 +3,13 @@
 <%@attribute name="displaySearch" required="true" type="java.lang.Boolean" %>
 <%@attribute name="title" required="false" type="java.lang.String" %>
 <%@attribute name="subtitle" required="false" type="java.lang.String" %>
+<%@attribute name="collection" required="false" type="java.lang.Object" %>
 
 <%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@taglib prefix="sec" uri="http://www.springframework.org/security/tags" %>
 <%@taglib prefix="cudl" tagdir="/WEB-INF/tags" %>
+<%@taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@taglib prefix="cudlfn" uri="/WEB-INF/cudl-functions.tld" %>
 
 <c:set var="defaultTitle" value="Cambridge Digital Library"/>
 
@@ -73,6 +76,7 @@
             <div class="banner-part"><h1><a href="/">Cambridge Digital Library</a></h1></div>
 
         </div>
-    </div>
 
+        <cudl:crumbtrail title="${title}" subtitle="${subtitle}" collection="${collection}" />
+    </div>
 </div>

--- a/src/main/webapp/WEB-INF/tags/page-title.tag
+++ b/src/main/webapp/WEB-INF/tags/page-title.tag
@@ -1,0 +1,12 @@
+<%@tag description="Add page title" pageEncoding="UTF-8" trimDirectiveWhitespaces="true" %>
+<%@attribute name="title" required="false" type="java.lang.String" %>
+<%@attribute name="additionalClasses" required="false" type="java.lang.String" %>
+
+<%@taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+
+<c:set var="defaultTitle" value="Cambridge Digital Library"/>
+
+<div class="pagetitle ${additionalClasses}">
+    <h1>${(not empty title) ? title : defaultTitle}</h1>
+</div>


### PR DESCRIPTION
Although the changes in this branch aren't overly complicated, there are some points that need to be considered before we decide how to deal with them:

The crumbtrail appears to work but it's not a very robust solution. If the idea of a crumbtrail meets approval, then it would likely be worthwhile implementing a more robust solution. This will likely require changes to the cudl.ui.json5 information (at the very least).

I created a tag to write the page title as it seems a necessary function. Firstly, if we implement a crumbtrail, all these titles will need to be easily accessible (perhaps in cudl.ui.json5). Secondly, most of the pages don't have page titles and the ones that appear to have one have it coded either in the page's main JSP file or in the imported HTML. It'd be safer in the long run and easier for editors to manage this information if it were recorded in one place. Perhaps we could add a mandatory Page title field to the page editor page. There might be some pages where we don't want the title to appear. If so, I suppose we could add a field that indicates whether it's to be displayed or not.

Linked to PR in cudl-viewer-ui