### PR TITLE
Add iframe default srcdoc to avoid unwanted Chrome history pushes

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/document.jsp
+++ b/src/main/webapp/WEB-INF/jsp/document.jsp
@@ -276,7 +276,9 @@
                                 <li class="active">Transcription</li>
                             </ol></div>
                             <div class="framediv">
-                            <iframe id="transcriptiondiploframe" src=""></iframe>
+                            <iframe id="transcriptiondiploframe"
+                                    src="" srcdoc="<html><head></head><body></body></html>">
+                            </iframe>
                             </div>
 
                         </div>
@@ -285,7 +287,9 @@
                                 <li class="active">Translation</li>
                             </ol></div>
                             <div class="framediv">
-                            <iframe id="translationframe" src=""></iframe>
+                            <iframe id="translationframe"
+                                    src="" srcdoc="<html><head></head><body></body></html>">
+                            </iframe>
                             </div>
                         </div>
                         <div role="tabpanel" class="tab-pane" id="download">


### PR DESCRIPTION
This PR partly fixes a bug that prevents the browser back button from functioning as intended when paging through items viewed in Chrome browser.

Please see full explanation: https://github.com/cambridge-collection/cudl-viewer-ui/pull/14