### PR TITLE
Remove srcdoc as it's no longer needed

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/document.jsp
+++ b/src/main/webapp/WEB-INF/jsp/document.jsp
@@ -276,9 +276,7 @@
                                 <li class="active">Transcription</li>
                             </ol></div>
                             <div class="framediv">
-                            <iframe id="transcriptiondiploframe"
-                                    src="" srcdoc="<html><head></head><body></body></html>">
-                            </iframe>
+                            <iframe id="transcriptiondiploframe" src=""></iframe>
                             </div>
 
                         </div>
@@ -287,9 +285,7 @@
                                 <li class="active">Translation</li>
                             </ol></div>
                             <div class="framediv">
-                            <iframe id="translationframe"
-                                    src="" srcdoc="<html><head></head><body></body></html>">
-                            </iframe>
+                            <iframe id="translationframe" src=""></iframe>
                             </div>
                         </div>
                         <div role="tabpanel" class="tab-pane" id="download">


### PR DESCRIPTION
srcdoc was added to help avoid spurious entries within the browser history. It's no longer necessary (and indeed gets in the way) with the working 'back' function in the cudl-viewer-ui PR.