### PR TITLE
Add 'home' class to enable different header behaviour on homepage

### DIFF
--- a/src/main/webapp/WEB-INF/tags/nav.tag
+++ b/src/main/webapp/WEB-INF/tags/nav.tag
@@ -13,7 +13,7 @@
 
 <c:set var="defaultTitle" value="Cambridge Digital Library"/>
 
-<div class="content main-nav-section">
+<div class="content main-nav-section ${(activeMenuIndex == 0) ? 'home' : ''}">
 
     <div class="container clearfix">
         <div class="fixed-top">


### PR DESCRIPTION
This PR is related to an associated one on the cudl-viewer-ui.