### PR TITLE
Add skip to content hyperlink

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/about-dl-platform.jsp
+++ b/src/main/webapp/WEB-INF/jsp/about-dl-platform.jsp
@@ -15,7 +15,7 @@
     <jsp:body>
         <cudl:nav activeMenuIndex="${4}" displaySearch="true" subtitle="Community"/>
 
-        <div class="campl-row campl-content campl-recessed-content">
+        <div id="main_content" class="campl-row campl-content campl-recessed-content">
             <div class="campl-wrap clearfix">
                 <cudl:about-nav />
                 <div class="campl-column8  campl-main-content" id="content">

--- a/src/main/webapp/WEB-INF/jsp/about.jsp
+++ b/src/main/webapp/WEB-INF/jsp/about.jsp
@@ -14,7 +14,7 @@
 
     <jsp:body>
         <cudl:nav activeMenuIndex="${4}" displaySearch="true" subtitle="Introducing the Cambridge Digital Library"/>
-        <div class="campl-row campl-content campl-recessed-content">
+        <div id="main_content" class="campl-row campl-content campl-recessed-content">
             <div class="campl-wrap clearfix">
                 <cudl:about-nav/>
                 <div class="campl-column6  campl-main-content" id="content">

--- a/src/main/webapp/WEB-INF/jsp/accessdenied.jsp
+++ b/src/main/webapp/WEB-INF/jsp/accessdenied.jsp
@@ -6,7 +6,7 @@
 <cudl:generic-page pagetype="STANDARD">
     <cudl:nav activeMenuIndex="${2}" displaySearch="true" title="Access Denied"/>
 
-    <div class="campl-row campl-content campl-recessed-content">
+    <div id="main_content" class="campl-row campl-content campl-recessed-content">
         <div class="campl-wrap clearfix">
             <div class="campl-column12  campl-main-content" id="content">
                 <div class="campl-content-container">

--- a/src/main/webapp/WEB-INF/jsp/collection-organisation.jsp
+++ b/src/main/webapp/WEB-INF/jsp/collection-organisation.jsp
@@ -26,7 +26,7 @@
     <jsp:body>
         <cudl:nav activeMenuIndex="${1}" displaySearch="true" title="View all collections" collection="${collection}"/>
 
-        <div class="campl-row campl-content campl-recessed-content">
+        <div id="main_content" class="campl-row campl-content campl-recessed-content">
             <div class="campl-wrap clearfix">
                 <div class="campl-column7  campl-main-content" id="content">
                     <div id="summaryDiv" class="campl-content-container">

--- a/src/main/webapp/WEB-INF/jsp/collection-parent.jsp
+++ b/src/main/webapp/WEB-INF/jsp/collection-parent.jsp
@@ -20,7 +20,7 @@
     <jsp:body>
         <cudl:nav activeMenuIndex="${1}" displaySearch="true" title="View all collections"/>
 
-        <div class="campl-row campl-content campl-recessed-content">
+        <div id="main_content" class="campl-row campl-content campl-recessed-content">
             <div class="campl-wrap clearfix">
                 <!-- side nav -->
                 <div class="campl-column3">

--- a/src/main/webapp/WEB-INF/jsp/collection-virtual.jsp
+++ b/src/main/webapp/WEB-INF/jsp/collection-virtual.jsp
@@ -22,7 +22,7 @@
 
             <div class="clear"></div>
 
-            <div class="campl-row campl-content campl-recessed-content">
+            <div id="main_content" class="campl-row campl-content campl-recessed-content">
                 <div class="campl-wrap clearfix">
 
                     <div class="campl-column12  campl-main-content campl-content-container" id="content">

--- a/src/main/webapp/WEB-INF/jsp/collections.jsp
+++ b/src/main/webapp/WEB-INF/jsp/collections.jsp
@@ -14,7 +14,7 @@
     <jsp:body>
         <cudl:nav activeMenuIndex="${1}" displaySearch="true" title="${pagetitle}"/>
 
-        <div class="campl-row campl-content campl-recessed-content">
+        <div id="main_content" class="campl-row campl-content campl-recessed-content">
             <div class="campl-wrap clearfix">
                 <div class="campl-column12  campl-main-content" id="content">
                     <div id="collectionsDiv">

--- a/src/main/webapp/WEB-INF/jsp/contributors.jsp
+++ b/src/main/webapp/WEB-INF/jsp/contributors.jsp
@@ -17,7 +17,7 @@
         <cudl:nav activeMenuIndex="${4}" displaySearch="true"
                   subtitle="Contributors to the Cambridge Digital Library"/>
 
-        <div class="campl-row campl-content campl-recessed-content">
+        <div id="main_content" class="campl-row campl-content campl-recessed-content">
             <div class="campl-wrap clearfix">
                 <cudl:about-nav />
                 <div class="campl-column8  campl-main-content" id="content">

--- a/src/main/webapp/WEB-INF/jsp/errors/404.jsp
+++ b/src/main/webapp/WEB-INF/jsp/errors/404.jsp
@@ -6,7 +6,7 @@
 <cudl:generic-page pagetype="STANDARD">
     <cudl:nav activeMenuIndex="${0}" displaySearch="true" title="Page not found"/>
 
-    <div class="campl-row campl-content campl-recessed-content">
+    <div id="main_content" class="campl-row campl-content campl-recessed-content">
         <div class="campl-wrap clearfix">
             <div class="campl-column9  campl-main-content" id="content">
                 <div class="campl-content-container">

--- a/src/main/webapp/WEB-INF/jsp/errors/500.jsp
+++ b/src/main/webapp/WEB-INF/jsp/errors/500.jsp
@@ -10,7 +10,7 @@
 <cudl:generic-page pagetype="ERROR_500" title="Error">
     <cudl:nav activeMenuIndex="${0}" displaySearch="true" title="Error"/>
 
-    <div class="campl-row campl-content campl-recessed-content">
+    <div id="main_content" class="campl-row campl-content campl-recessed-content">
         <div class="campl-wrap clearfix">
             <div class="campl-column9  campl-main-content" id="content">
                 <div class="campl-content-container">

--- a/src/main/webapp/WEB-INF/jsp/essay.jsp
+++ b/src/main/webapp/WEB-INF/jsp/essay.jsp
@@ -11,7 +11,7 @@
     <cudl:nav activeMenuIndex="${1}" displaySearch="true"
               title="${organisationalCollection.title}"/>
 
-    <div class="campl-row campl-content campl-recessed-content">
+    <div id="main_content" class="campl-row campl-content campl-recessed-content">
         <div class="campl-wrap clearfix">
             <div class="campl-column12  campl-main-content" id="content">
 

--- a/src/main/webapp/WEB-INF/jsp/help.jsp
+++ b/src/main/webapp/WEB-INF/jsp/help.jsp
@@ -6,7 +6,7 @@
 <cudl:generic-page pagetype="STANDARD">
     <cudl:nav activeMenuIndex="${5}" displaySearch="true" title="Help: FAQ"/>
 
-    <div class="campl-row campl-content campl-recessed-content">
+    <div id="main_content" class="campl-row campl-content campl-recessed-content">
         <div class="campl-wrap clearfix">
             <div class="campl-column9  campl-main-content" id="content">
                 <div class="campl-content-container">

--- a/src/main/webapp/WEB-INF/jsp/index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/index.jsp
@@ -16,7 +16,7 @@
     <jsp:attribute name="pageData">
         <cudl:default-context>
             <cudl:context-editable-areas>
-                <cudl:editable-area id="indexDiv" filename="index.html"/>
+                <cudl:editable-area id="main_content" filename="index.html"/>
             </cudl:context-editable-areas>
         </cudl:default-context>
     </jsp:attribute>
@@ -32,7 +32,7 @@
             <c:out value="${downtimeWarning}" escapeXml="false"/>
         </c:if>
 
-        <div id="indexDiv">
+        <div id="main_content">
             <c:import charEncoding="UTF-8" url="${contentHTMLURL}/index.html" />
         </div>
     </jsp:body>

--- a/src/main/webapp/WEB-INF/jsp/login.jsp
+++ b/src/main/webapp/WEB-INF/jsp/login.jsp
@@ -10,7 +10,7 @@
 <cudl:generic-page pagetype="LOGIN">
     <cudl:nav activeMenuIndex="${3}" displaySearch="true" title="Sign in to My Library"/>
 
-    <div class="campl-row campl-content campl-recessed-content">
+    <div id="main_content" class="campl-row campl-content campl-recessed-content">
         <div class="campl-wrap clearfix">
             <div class="campl-column12  campl-main-content" id="content">
                 <div class="campl-content-container">

--- a/src/main/webapp/WEB-INF/jsp/mylibrary.jsp
+++ b/src/main/webapp/WEB-INF/jsp/mylibrary.jsp
@@ -17,7 +17,7 @@
 
     <div class="clear"></div>
 
-    <div class="campl-row campl-content campl-recessed-content">
+    <div id="main_content" class="campl-row campl-content campl-recessed-content">
         <div class="campl-wrap clearfix">
 
             <div class="campl-column7  campl-main-content" id="content">

--- a/src/main/webapp/WEB-INF/jsp/news.jsp
+++ b/src/main/webapp/WEB-INF/jsp/news.jsp
@@ -15,7 +15,7 @@
     <jsp:body>
         <cudl:nav activeMenuIndex="${4}" displaySearch="true" subtitle="News"/>
 
-        <div class="campl-row campl-content campl-recessed-content">
+        <div id="main_content" class="campl-row campl-content campl-recessed-content">
             <div class="campl-wrap clearfix">
                 <cudl:about-nav />
                 <div class="campl-column6  campl-main-content" id="content">

--- a/src/main/webapp/WEB-INF/jsp/search-advanced.jsp
+++ b/src/main/webapp/WEB-INF/jsp/search-advanced.jsp
@@ -10,7 +10,7 @@
 <cudl:generic-page pagetype="ADVANCED_SEARCH" title="${collection.title}">
     <cudl:nav activeMenuIndex="${2}" displaySearch="true" title="Advanced Search"/>
 
-    <div class="campl-row campl-content campl-recessed-content">
+    <div id="main_content" class="campl-row campl-content campl-recessed-content">
         <div class="campl-wrap clearfix">
             <div class="campl-column12  campl-main-content" id="content">
                 <div class="campl-content-container">

--- a/src/main/webapp/WEB-INF/jsp/terms.jsp
+++ b/src/main/webapp/WEB-INF/jsp/terms.jsp
@@ -7,7 +7,7 @@
 <cudl:generic-page pagetype="STANDARD" title="Terms & Conditions">
     <cudl:nav activeMenuIndex="${4}" displaySearch="true" subtitle="Terms & Conditions"/>
 
-    <div class="campl-row campl-content campl-recessed-content">
+    <div id="main_content" class="campl-row campl-content campl-recessed-content">
         <div class="campl-wrap clearfix">
             <cudl:about-nav />
             <div class="campl-column8  campl-main-content" id="content">

--- a/src/main/webapp/WEB-INF/tags/html.tag
+++ b/src/main/webapp/WEB-INF/tags/html.tag
@@ -13,6 +13,7 @@
     <jsp:invoke fragment="head"/>
 </head>
 <body<jsp:invoke fragment="bodyAttrs"/>>
+  <a href="#main_content" class="campl-skipTo">skip to content</a>
   <jsp:doBody/>
 </body>
 </html>

--- a/src/main/webapp/WEB-INF/tags/search-results-page.tag
+++ b/src/main/webapp/WEB-INF/tags/search-results-page.tag
@@ -23,7 +23,7 @@
     <jsp:body>
         <cudl:nav activeMenuIndex="${2}" displaySearch="true" title="${title}"/>
 
-        <div class="campl-row campl-content campl-recessed-content">
+        <div id="main_content" class="campl-row campl-content campl-recessed-content">
             <div class="campl-wrap clearfix">
                 <div class="campl-main-content" id="content">
                     <div class="campl-column4 campl-secondary-content">


### PR DESCRIPTION
Needs testing in Firefox. Firefox on OSX doesn't seem to support tabbing - at least, not without making some config changes I haven't figured out yet. But, the feature appears to work in Safari and Chrome. 