### PR TITLE
Change subjects search  to subject

### DIFF
--- a/src/main/java/ulcambridge/foundations/viewer/forms/SearchForm.java
+++ b/src/main/java/ulcambridge/foundations/viewer/forms/SearchForm.java
@@ -102,7 +102,7 @@ public class SearchForm {
     }
 
     public boolean hasAdvancedParams() {
-        return (this.getAuthor() != "" || this.getFacetCollection() != null || this.getFullText() != "" || this.getLanguage() != "" || this.getLocation() != "" || this.getPlace() != "" || this.getShelfLocator() != "" || this.getSubjects() != "" || this.getTitle() != "" || this.getYearEnd() != null || this.getYearStart() != null);
+        return (this.getAuthor() != "" || this.getFacetCollection() != null || this.getFullText() != "" || this.getLanguage() != "" || this.getLocation() != "" || this.getPlace() != "" || this.getShelfLocator() != "" || this.getSubject() != "" || this.getTitle() != "" || this.getYearEnd() != null || this.getYearStart() != null);
     }
 
     public String getKeyword() {
@@ -172,7 +172,7 @@ public class SearchForm {
         this.author = author;
     }
 
-    public String getSubjects() {
+    public String getSubject() {
         return subject;
     }
 

--- a/src/main/java/ulcambridge/foundations/viewer/search/SearchUtil.java
+++ b/src/main/java/ulcambridge/foundations/viewer/search/SearchUtil.java
@@ -37,7 +37,7 @@ public final class SearchUtil {
             .queryParam("shelfLocator", searchForm.getShelfLocator())
             .queryParam("title", searchForm.getTitle())
             .queryParam("author", searchForm.getAuthor())
-            .queryParam("subjects", searchForm.getSubjects())
+            .queryParam("subject", searchForm.getSubject())
             .queryParam("language", searchForm.getLanguage())
             .queryParam("place", searchForm.getPlace())
             .queryParam("location", searchForm.getLocation())

--- a/src/main/java/ulcambridge/foundations/viewer/search/SolrSearch.java
+++ b/src/main/java/ulcambridge/foundations/viewer/search/SolrSearch.java
@@ -163,8 +163,8 @@ public class SolrSearch implements Search {
             QueryTerms.put("name", searchForm.getAuthor());
         }
 
-        if (searchForm.getSubjects() != null) {
-            QueryTerms.put("subjects", searchForm.getSubjects());
+        if (searchForm.getSubject() != null) {
+            QueryTerms.put("subjects", searchForm.getSubject());
         }
 
         if (searchForm.getLanguage() != null) {

--- a/src/main/webapp/WEB-INF/jsp/search-advanced.jsp
+++ b/src/main/webapp/WEB-INF/jsp/search-advanced.jsp
@@ -137,11 +137,11 @@
 
                                         <div class="row">
                                             <div class="col-md-2">
-                                                <form:label class="right" path="subjects">Subjects</form:label>
+                                                <form:label class="right" path="subject">Subjects</form:label>
                                             </div>
                                             <div class="col-md-10">
                                     <span class="hint--right" data-hint="Search for items about this subject, e.g. Mathematics">
-                                        <form:input path="subjects" type="text" size="35" value="" name="subjects"/>
+                                        <form:input path="subject" type="text" size="35" value="" name="subject"/>
                                     </span>
                                             </div>
                                         </div>

--- a/src/main/webapp/WEB-INF/jsp/search-advancedresults.jsp
+++ b/src/main/webapp/WEB-INF/jsp/search-advancedresults.jsp
@@ -31,7 +31,7 @@
             <cudl:search-result-param form="${form}" label="CUDL ID" attr="fileID"/>
             <cudl:search-result-param form="${form}" label="Title" attr="title"/>
             <cudl:search-result-param form="${form}" label="Author" attr="author"/>
-            <cudl:search-result-param form="${form}" label="Subjects" attr="subjects"/>
+            <cudl:search-result-param form="${form}" label="Subjects" attr="subject"/>
             <cudl:search-result-param form="${form}" label="Language" attr="language"/>
             <cudl:search-result-param form="${form}" label="Associated Place or Origin" attr="place"/>
             <cudl:search-result-param form="${form}" label="Current Location" attr="location"/>

--- a/src/main/webapp/WEB-INF/jsp/search-results.jsp
+++ b/src/main/webapp/WEB-INF/jsp/search-results.jsp
@@ -21,7 +21,7 @@
             <cudl:search-result-param form="${form}" label="CUDL ID" attr="fileID"/>
             <cudl:search-result-param form="${form}" label="Title" attr="title"/>
             <cudl:search-result-param form="${form}" label="Author" attr="author"/>
-            <cudl:search-result-param form="${form}" label="Subjects" attr="subjects"/>
+            <cudl:search-result-param form="${form}" label="Subjects" attr="subject"/>
             <cudl:search-result-param form="${form}" label="Language" attr="language"/>
             <cudl:search-result-param form="${form}" label="Associated Place or Origin" attr="place"/>
             <cudl:search-result-param form="${form}" label="Current Location" attr="location"/>


### PR DESCRIPTION
The old URL param for the subject search was 'subject' (singular), not plural.