### PR TITLE
Update CodeBuild documentation and update Terraform build for CodeBuild to use stable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ docker push "$AWS_ACCOUNT_ID_B.dkr.ecr.$AWS_REGION_B.amazonaws.com/cudl/viewer:l
 
 where `AWS_ACCOUNT_ID_B`, `ENVIRONMENT_B` and `AWS_REGION_B` all refer to the target repository.
 
+As previously noted the WAR file needs to be deployed to Tomcat with a properties file `cudl-global.properties`. An example can be seen [here](https://github.com/cambridge-collection/cudl-viewer/blob/main/docker/cudl-global.properties). This file also needs to be available to the ECS deployment.
+
+The image is built with an `entrypoint.sh` script that reads the value of an environment variable `S3_URL` and uses the AWS CLI to copy the file indicated to the path `/etc/cudl-viewer/cudl-global.properties`. This will be read by the Viewer application on startup. This can be configured in ECS by setting an environment variable `S3_URL` in the container definition and giving the ECS task permission to access the S3 location specified.
+
 ### Errors running CodeBuild
 
 We have seen a frequent error during the docker build step e.g.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,57 @@ This file will be excluded from any WAR file generated as it contains the proper
 that vary between systems (DEV, BETA, LIVE etc). This file should be copied into the
 classpath for your web container (e.g. `lib` directory in Tomcat).
 
+### Deploying to ECS
+
+The Live site is deployed to AWS ECS. This uses an Apache Tomcat container image to run the WAR file. To deploy a new version of the Viewer to ECS, a new Docker Image will need to be built. Currently images for the Live site are built using AWS CodeBuild.
+
+Infrastructure supporting the CodeBuild project can be built using the Terraform code in the `terraform/` subdirectory. This code will create the CodeBuild project, ECR Repository, SSM Parameters and IAM permissions. The CodeBuild project is configured to build the project https://github.com/cambridge-collection/cudl-viewer.git and the `main` branch.
+
+CodeBuild will automatically detect the `buildspec.yml` file contained at the root of this project. This describes the steps that CodeBuild will run as part of a build. Currently CodeBuild will build the WAR file using Maven, build the container image using Docker, and push the image to the ECR repository.
+
+The Maven part of the build is dependent on two files that would normally be located in the user's `.m2` directory: `toolchains.xml` and `settings.xml`. The file `toolchains.xml` configures the JDK to be used by CodeBuild. The Maven build is dependent on a JAR file obtained from the GitHub repositiory https://github.com/orgs/cambridge-collection/packages?repo_name=cudl-viewer-ui. The file `settings.xml` sets up credentials that allow CodeBuild to authenticate with GitHub to download the package required. The SSM Parameters created by Terraform are used to supply values for the GITHUB_USER and GITHUB_TOKEN environment variables associated with the project referred to in `settings.xml`. Note that the parameters created by Terraform will likely need to be updated manually to supply actual values. The build has been tested with a classic Personal Access Token with `read:packages` scope.
+
+The Docker part of the build refers to the Dockerfile at `docker/ui/Dockerfile`.
+
+Each build will need to be triggered manually in the AWS Console. Once complete a new tagged version of the image will be available in ECR.
+
+It may be necessary to pull the image from the ECR repository used by CodeBuild to push the image to another AWS Account for deployment. the new image version will need to be referenced in the `image` property of an ECS Container Definition to be deployed to a new ECS task.
+
+To pull the image you can login with docker using the command
+
+```sh
+aws ecr get-login-password --region $AWS_REGION_A | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID_A.dkr.ecr.$AWS_REGION_A.amazonaws.com
+docker pull $AWS_ACCOUNT_ID_A.dkr.ecr.$AWS_REGION_A.amazonaws.com/$ENVIRONMENT_A-cudl-viewer:latest
+```
+
+where `AWS_ACCOUNT_ID_A` is the AWS Account ID of the source account, `ENVIRONMENT_A` is the name of the environment prefixed to the ECR Repository, and `AWS_REGION_A` is the source AWS region.
+
+Then tag the image and push to the alternative ECR repository
+
+```sh
+docker tag "$AWS_ACCOUNT_ID_A.dkr.ecr.$AWS_REGION_A.amazonaws.com/$ENVIRONMENT_A-cudl-viewer:latest" "$AWS_ACCOUNT_ID_B.dkr.ecr.$AWS_REGION_B.amazonaws.com/cudl/viewer:latest"
+aws ecr get-login-password --region $AWS_REGION_B | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID_B.dkr.ecr.$AWS_REGION_B.amazonaws.com
+docker push "$AWS_ACCOUNT_ID_B.dkr.ecr.$AWS_REGION_B.amazonaws.com/cudl/viewer:latest"
+```
+
+where `AWS_ACCOUNT_ID_B`, `ENVIRONMENT_B` and `AWS_REGION_B` all refer to the target repository.
+
+### Errors running CodeBuild
+
+We have seen a frequent error during the docker build step e.g.
+
+```
+Sending build context to Docker daemon  387.7MB
+
+Step 1/11 : FROM --platform=linux/amd64 tomcat:9.0.30-jdk11-openjdk
+toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
+
+Command did not exit successfully docker build -t $REPOSITORY_URI_VIEWER:latest -f docker/ui/Dockerfile . exit status 1
+Phase complete: BUILD State: FAILED
+```
+
+As can be seen this is due to rate throttling in DockerHub, presumably due to the shared addresses used by CodeBuild to access DockerHub leading to a high volume of requests. We have found the build will succeed after a few reattempts.
+
 ## Making a release
 
 Releasing is using the Maven release plugin.
@@ -178,9 +229,6 @@ to the CUDL packages repository in GitHub using the command:
 ```
 $ mvn release:perform
 ```
-
-Once you have performed the release, the latest version of your application will be automatically built into a Docker
-image using AWS CodeDeploy and is then available in the [sandbox ECR](https://eu-west-1.console.aws.amazon.com/ecr/repositories/private/563181399728/sandbox-cudl-viewer?region=eu-west-1).
 
 ## More information
 

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -2,8 +2,3 @@ resource "aws_ecr_repository" "cudl_viewer" {
   name         = join("-", [var.tag_environment, "cudl-viewer"])
   force_delete = var.ecr_repository_force_delete
 }
-
-resource "aws_ecr_repository" "cudl_viewer_db" {
-  name         = join("-", [var.tag_environment, "cudl-viewer-db"])
-  force_delete = var.ecr_repository_force_delete
-}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -106,7 +106,6 @@ data "aws_iam_policy_document" "code_build" {
     ]
     resources = [
       aws_ecr_repository.cudl_viewer.arn,
-      aws_ecr_repository.cudl_viewer_db.arn,
     ]
   }
 

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -13,5 +13,5 @@ terraform {
     region         = "eu-west-1"
   }
 
-  required_version = "~> 1.7.5"
+  required_version = "~> 1.9.7"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -60,7 +60,7 @@ variable "codebuild_git_submodule_data_samples" {
 
 variable "codebuild_git_source_version" {
   type        = string
-  default     = "feature/codebuild-with-removed-db"
+  default     = "main"
   description = "Git branch to use in CodeBuild project"
 }
 


### PR DESCRIPTION
- Add new sections to `README.md`
- Update `terraform/terraform.tf` to use Terraform version 1.9.7
- Remove `aws_ecr_repository.cudl_viewer_db` resource
- Remove reference to `aws_ecr_repository.cudl_viewer_db.arn` in `aws_iam_policy_document.code_build`
- Update value of `codebuild_git_source_version` to refer to `main` branch
