### PR TITLE
Add docker maven build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "data/dl-data-samples"]
 	path = data/dl-data-samples
-	url = git@github.com:cambridge-collection/dl-data-samples.git
-[submodule "docker/db/dl-data-samples-http"]
-	path = docker/db/dl-data-samples-http
 	url = https://github.com/cambridge-collection/dl-data-samples.git

--- a/docker/ui/context.xml
+++ b/docker/ui/context.xml
@@ -3,7 +3,7 @@ This is a Context file used when deploying the viewer webapp in the development
 Tomcat docker container.
 -->
 <Context reloadable="true">
-    <Resources>
+    <Resources cachingAllowed="true" cacheMaxSize="100000">
         <!-- Map the global properties file into the Viewer webapp's classpath
              so that it can load it.
              NOTE this file is not present in the image and must be obtained at

--- a/docker/ui/gitlab.Dockerfile
+++ b/docker/ui/gitlab.Dockerfile
@@ -1,0 +1,42 @@
+FROM maven:3.9.9-amazoncorretto-11 AS maven
+
+ARG GITHUB_USER GITHUB_TOKEN
+
+WORKDIR /opt/build
+
+COPY pom.xml toolchains.xml settings.xml .
+COPY src ./src
+
+RUN mvn -s settings.xml -t toolchains.xml clean package;
+
+FROM tomcat:9.0.30-jdk11-openjdk AS tomcat
+
+ENV JAVA_OPTS="-server -Djava.awt.headless=true -Xms512m -Xmx2560m" \
+    VIEWER_USER="digilib" \
+    VIEWER_UID="1729" \
+    VIEWER_GROUP="digilib" \
+    VIEWER_GID="1729"
+
+COPY --from=maven /opt/build/target/FoundationsViewer.war $CATALINA_HOME/webapps/ROOT.war
+COPY docker/ui/server.xml $CATALINA_HOME/conf/server.xml
+COPY docker/ui/context.xml $CATALINA_HOME/conf/Catalina/localhost/ROOT.xml
+COPY docker/ui/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+RUN set -ex; \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"; \
+    unzip awscliv2.zip; \
+    ./aws/install; \
+    aws --version;
+
+RUN set -ex; \
+    chmod 0755 /usr/local/bin/entrypoint.sh; \
+    groupadd -r --gid "$VIEWER_GID" "$VIEWER_GROUP"; \
+    useradd -r --uid "$VIEWER_UID" --gid "$VIEWER_GID" "$VIEWER_USER"; \
+    chown -R $VIEWER_USER:$VIEWER_GROUP $CATALINA_HOME; \
+    mkdir -p /etc/cudl-viewer; \
+    chown -R $VIEWER_USER:$VIEWER_GROUP /etc/cudl-viewer;
+
+USER digilib
+
+ENTRYPOINT [ "entrypoint.sh" ]
+CMD [ "catalina.sh", "run" ]


### PR DESCRIPTION
Add new `Dockerfile` and update submodule for compatibility with Gitlab CI

- Add `docker/ui/gitlab.Dockerfile` with maven target to  to build the WAR file and copy to the Tomcat image. The GitLab runner does not have maven installed so this change is necessary to make the image build in GitLab
- Update `data/dl-data-samples` submodule to use https and remove `docker/db/dl-data-samples-http` submodule as GitLab is unable to clone from GitHub using SSH
- Add `cachingAllowed` and `cacheMaxSize` properties to `Resources` tag of `docker/ui/context.xml` to avoid warnings in log such as

```
08-Jan-2025 14:47:53.677 WARNING [catalina-exec-589] org.apache.catalina.webresources.Cache.getResource Unable to add the resource at [/WEB-INF/tags/ie-div.tag] to the cache for web application [] because there was insufficient free space available after evicting expired cache entries - consider increasing the maximum size of the cache
```