### PR TITLE
fix(thumbnails): use IIIF best-fit bounding box for appendToThumbnail requests

### DIFF
--- a/docker/cudl-global.properties
+++ b/docker/cudl-global.properties
@@ -41,7 +41,7 @@ IIIFImageServer=https://images.lib.cam.ac.uk/iiif/
 RTIImageServer=https://rti-images.cudl-sandbox.net/rti/
 
 # Value to append to image server URL (default is jp2)
-appendToThumbnail=.jp2/full/,180/0/default.jpg
+appendToThumbnail=.jp2/full/!180,180/0/default.jpg
 appendToImage=.jp2
 
 # Email address to send the feedback form to.

--- a/docker/sample-global.properties
+++ b/docker/sample-global.properties
@@ -41,7 +41,7 @@ IIIFImageServer=http://localhost:1114/
 RTIImageServer=https://rti-images.cudl-sandbox.net/rti/
 
 # Value to append to image server URL (default is jp2)
-appendToThumbnail=/full/,180/0/default.jpg
+appendToThumbnail=/full/!180,180/0/default.jpg
 appendToImage=
 
 # Email address to send the feedback form to.

--- a/src/test/java/ulcambridge/foundations/viewer/dao/items/huwiiifdataworkaround/ImageURLResolutionTest.java
+++ b/src/test/java/ulcambridge/foundations/viewer/dao/items/huwiiifdataworkaround/ImageURLResolutionTest.java
@@ -105,42 +105,42 @@ public class ImageURLResolutionTest extends BaseCUDLApplicationContextTest {
             "displayImageURL", "content/images/MS-ADD-03419-000-00001",
             "downloadImageURL", "MS-ADD-03419-000-00001",
             "IIIFImageURL", "MS-ADD-03419-000-00001.jp2",
-            "thumbnailImageURL", "MS-ADD-03419-000-00001.jp2/full/,180/0/default.jpg"
+            "thumbnailImageURL", "MS-ADD-03419-000-00001.jp2/full/!180,180/0/default.jpg"
         );
 
         assertThat(item.getJSON().getJSONArray("pages").getJSONObject(1).toMap()).containsAtLeast(
             "displayImageURL", "content/images/MS-ADD-03419-000-00002",
             "downloadImageURL", "MS-ADD-03419-000-00002",
             "IIIFImageURL", "MS-ADD-03419-000-00002.jp2",
-            "thumbnailImageURL", "MS-ADD-03419-000-00002.jp2/full/,180/0/default.jpg"
+            "thumbnailImageURL", "MS-ADD-03419-000-00002.jp2/full/!180,180/0/default.jpg"
         );
     }
 
     @Test
     public void itemObjectReportsExpectedPageThumbnailURLs() {
         assertThat(item.getPageThumbnailURLs()).containsExactly(
-            "MS-ADD-03419-000-00001.jp2/full/,180/0/default.jpg",
-            "MS-ADD-03419-000-00002.jp2/full/,180/0/default.jpg"
+            "MS-ADD-03419-000-00001.jp2/full/!180,180/0/default.jpg",
+            "MS-ADD-03419-000-00002.jp2/full/!180,180/0/default.jpg"
         );
     }
 
     @Test
     public void descriptiveMetadataSectionsHaveThumbnailURLGenerated() {
         assertThat(item.getJSON().getJSONArray("descriptiveMetadata").getJSONObject(0).toMap()).containsAtLeast(
-            "thumbnailUrl", "MS-ADD-03419-000-00001.jp2/full/,180/0/default.jpg"
+            "thumbnailUrl", "MS-ADD-03419-000-00001.jp2/full/!180,180/0/default.jpg"
         );
 
         assertThat(item.getJSON().getJSONArray("descriptiveMetadata").getJSONObject(1).toMap())
             .doesNotContainKey("thumbnailUrl");
 
         assertThat(item.getJSON().getJSONArray("descriptiveMetadata").getJSONObject(2).toMap()).containsAtLeast(
-            "thumbnailUrl", "MS-ADD-03419-000-00034.jp2/full/,180/0/default.jpg"
+            "thumbnailUrl", "MS-ADD-03419-000-00034.jp2/full/!180,180/0/default.jpg"
         );
     }
 
     @Test
     public void itemObjectsReportExpectedThumbnailURL() {
-        final String expectedURL = imageServerURL.resolve("MS-ADD-03419-000-00001.jp2/full/,180/0/default.jpg").toString();
+        final String expectedURL = imageServerURL.resolve("MS-ADD-03419-000-00001.jp2/full/!180,180/0/default.jpg").toString();
         assertThat(item.getThumbnailURL()).isEqualTo(expectedURL);
         assertThat(item.getSimplifiedJSON().getString("thumbnailURL")).isEqualTo(expectedURL);
     }

--- a/src/test/resources/ulcambridge/foundations/viewer/test-defaults.properties
+++ b/src/test/resources/ulcambridge/foundations/viewer/test-defaults.properties
@@ -11,7 +11,7 @@ rootURL=http://digital.library.example.com
 imageServer=http://images.digital.library.example.com/simple/
 IIIFImageServer=http://images.digital.library.example.com/iiif/
 RTIImageServer=https://images.digital.library.example.com/rti/
-appendToThumbnail=.jp2/full/,180/0/default.jpg
+appendToThumbnail=.jp2/full/!180,180/0/default.jpg
 appendToImage=.jp2
 
 itemJSONDirectory=src/test/resources/cudl-data/


### PR DESCRIPTION
Request thumbnails using IIIF best-fit bounding boxes. This preserves the aspect ratio of the image and ensure that very tall/wide images are properly scaled to fit within the ui. 

This change likely isn't needed since the image is already forceable scaled to 180x180 max by the css. But it does ensure: a) that the images will always fit reliably inside this box. It'll also make some thumbnails smaller. A 180px wide tall page stub image is much larger than one that is bound to a max of 180px wide as well. b) it helps ensure that we won't have to keep playing whackamole with css sizing issues with the thumbnails. 